### PR TITLE
feat: Add packit automation

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,32 @@
+packages:
+  atuin:
+    specfile_path: atuin.spec
+    files_to_sync:
+      - atuin.spec
+      - .packit.yaml
+    upstream_package_name: atuin
+    downstream_package_name: atuin
+    actions:
+      create-archive:
+        - spectool -g -s0 atuin.spec
+        - sh -c 'echo v${PACKIT_PROJECT_VERSION}.tar.gz'
+      get-current-version:
+        - rpmspec -q --qf "%{Version}" --srpm atuin.spec
+
+jobs:
+  - job: copr_build
+    trigger: commit
+    owner: sramanujam
+    project: atuin
+    targets:
+      - fedora-all
+      - epel-9
+    enable_net: true
+  - job: copr_build
+    trigger: pull_request
+    owner: sramanujam
+    project: atuin
+    targets:
+      - fedora-all
+      - epel-9
+    enable_net: true


### PR DESCRIPTION
This is an alternative to the webhook automation via `copr`. You would need to install the [app](https://packit.dev/docs/guide), but other than that you should be fine since you already have a copr account.

I am adding this because it seems `bash-preexec` would be needed as well, and it would be easier if both are built together. Otherwise, you might be able to set it up to build multiple packages via the webhook as well :shrug: 

Ended up a bit more complicated because you've implied internet connection on copr. That would be problematic when uploading to Fedora, so I've changed it to be more in line with `rust2rpm`

Debugging on fork: https://github.com/LecrisUT/atuin-rpmspec/pull/1